### PR TITLE
KNMA-1764: Update Close Icon for iOS

### DIFF
--- a/ios/Classes/VerticalPlayerViewController.swift
+++ b/ios/Classes/VerticalPlayerViewController.swift
@@ -15,8 +15,8 @@ class VerticalPlayerViewController: JWPlayerViewController {
     private let closeButton: UIButton = {
         if #available(iOS 13.0, *) {
             let closeButton = UIButton(type: .close)
-            closeButton.backgroundColor = .white
-            closeButton.layer.cornerRadius = 20 
+            closeButton.backgroundColor = .black
+            closeButton.layer.cornerRadius = 20
             return closeButton
         } else {
             let closeButton = UIButton()
@@ -31,6 +31,19 @@ class VerticalPlayerViewController: JWPlayerViewController {
             return closeButton
         }
     }()
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        
+        if #available(iOS 13.0, *) {
+            if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                self.setCloseButtonBackground()
+            }
+        } else {
+            // Fallback on earlier versions
+        }
+    }
+
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -59,15 +72,24 @@ class VerticalPlayerViewController: JWPlayerViewController {
         }
     }
     
+    private func setCloseButtonBackground() {
+        if traitCollection.userInterfaceStyle == .dark {
+            closeButton.backgroundColor = .black
+        } else {
+            closeButton.backgroundColor = .white
+        }
+    }
+    
     private func setupUI() {
+        self.setCloseButtonBackground()
         self.view.addSubview(closeButton)
         self.closeButton.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate([
-            closeButton.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor, constant: 10),
-            closeButton.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -10),
-            closeButton.widthAnchor.constraint(equalToConstant: 40),
-            closeButton.heightAnchor.constraint(equalToConstant: 40),
+            closeButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 16),
+            closeButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
+            closeButton.widthAnchor.constraint(equalToConstant: 40), // Set icon size
+            closeButton.heightAnchor.constraint(equalToConstant: 40)
         ])
     }
     


### PR DESCRIPTION
### Jira Ticket Link.

https://jiratl.kqed.org/browse/KNMA-1764

### Describe the feature or bug-fix.

The Close X Icon would change color when the iOS device is in Light or Dark Mode. So using the hardcoded background color is not acceptable. This adds code to change close button's background color based on the mode. This also moves the close button to the Top Left. Since it being in the Top Right was hiding some functionality from the player.

### Express how you feel about this PR with a GIF.

![](https://media.giphy.com/media/Y20V0jRsaiFs8cfoaX/giphy.gif?cid=790b7611ivqnlocx0hgrvzb7yt21zcuupa53exebpleofcam&ep=v1_gifs_search&rid=giphy.gif&ct=g)


### What areas of the App does it impact?

- iOS Plugin

### How to test? Be specific here. Call out any Environment or Accessibility pieces if applicable.

- Using iOS
- Use either the example app or the kqed mobile app
- If using the kqed mobile app, override the git location to use the local path or the git sha of the PR.
- Build, launch and go to vertical video.
- Launch a vertical video, see the icon on top left. 
- Change to Light or Dark mode, see icon color update

### Was documentation written or updated? If so, provide the link or links.

N/A

