### PR TITLE
KNMA-1822 Vertical video captions

### DIFF
--- a/android/src/main/kotlin/com/kqed/jwplayer/jwplayer/JwPlayerActivity.kt
+++ b/android/src/main/kotlin/com/kqed/jwplayer/jwplayer/JwPlayerActivity.kt
@@ -6,6 +6,8 @@ import androidx.appcompat.app.AppCompatActivity
 import com.jwplayer.pub.api.configuration.PlayerConfig
 import com.jwplayer.pub.api.media.playlists.PlaylistItem
 import com.jwplayer.pub.view.JWPlayerView
+import com.jwplayer.pub.api.media.captions.Caption
+import com.jwplayer.pub.api.media.captions.CaptionType
 
 class JwPlayerActivity : AppCompatActivity() {
 
@@ -19,9 +21,24 @@ class JwPlayerActivity : AppCompatActivity() {
 
         val view = findViewById<JWPlayerView>(R.id.jwPlayerView)
         val url = intent.getStringExtra("url")
+        val captionUrl = intent.getStringExtra("captionUrl")
+        val captionLocale = intent.getStringExtra("captionLocale")
+        val captionLanguageLabel = intent.getStringExtra("captionLanguageLabel")
+
+        val captionTracks: ArrayList<Caption> = ArrayList();
+
+        val captionEn: Caption = Caption.Builder()
+            .file(captionUrl)
+            .label(captionLanguageLabel)
+            .kind(CaptionType.CAPTIONS)
+            .isDefault(true)
+            .build();
+            
+        captionTracks.add(captionEn);
 
         val playlistItem = PlaylistItem.Builder()
             .file(url)
+            .tracks(captionTracks)
             .build()
         val playlist: MutableList<PlaylistItem> = ArrayList()
         playlist.add(playlistItem)

--- a/android/src/main/kotlin/com/kqed/jwplayer/jwplayer/JwplayerPlugin.kt
+++ b/android/src/main/kotlin/com/kqed/jwplayer/jwplayer/JwplayerPlugin.kt
@@ -45,11 +45,23 @@ class JwplayerPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
         PluginMethods.Play.value -> {
           val urlArg = "url"
+          val captionUrlArg = "captionUrl"
+          val captionLocaleArg = "captionLocale"
+          val captionLanguageLabelArg = "captionLanguageLabel"
 
           val argumentData = call.arguments as? Map<*, *>
+
           val url = argumentData?.get(urlArg)
+          val captionUrl = argumentData?.get(captionUrlArg)
+          val captionLocale = argumentData?.get(captionLocaleArg)
+          val captionLanguageLabel = argumentData?.get(captionLanguageLabelArg)
+
           val myIntent = Intent(boundActivity, JwPlayerActivity::class.java)
-          myIntent.putExtra("url", url.toString()) //Optional parameters
+          myIntent.putExtra("url", url.toString())
+          myIntent.putExtra("captionUrl", captionUrl.toString())
+          myIntent.putExtra("captionLocale", captionLocale.toString())
+          myIntent.putExtra("captionLanguageLabel", captionLanguageLabel.toString())
+
           boundActivity?.startActivity(myIntent)
           callbackToFlutterApp(
             CallbackMethod.sdkPlayMethodCalled.methodKey,

--- a/ios/Classes/VerticalPlayerViewController.swift
+++ b/ios/Classes/VerticalPlayerViewController.swift
@@ -60,8 +60,6 @@ class VerticalPlayerViewController: JWPlayerViewController {
             let skin = try JWPlayerSkinBuilder()
                 .titleIsVisible(videoTitle != nil && !(videoTitle?.isEmpty ?? true))
                 .descriptionIsVisible(videoDescription != nil && !(videoDescription?.isEmpty ?? true))
-            // Change the font for both title and description
-            // .font(UIFont (name: "HelveticaNeue-UltraLight", size: 30)!)
                 .build()
             // Set skin for player
             // Specifically, for us, show/hide title and description
@@ -105,27 +103,11 @@ class VerticalPlayerViewController: JWPlayerViewController {
         
         // Setup the default rendering style for side-loaded captions.
         do {
-            // Change the default position for the caption
-//            let position = try JWCaptionPositionBuilder()
-//                .width(percentage: 100)
-//                .horizontalPosition(percentage: 0)
-//                .alignment(.center)
-//                .verticalPosition(lineIndex: 0)
-//                .build()
-            
             // Change the caption style
             let style = try JWCaptionStyleBuilder()
-//                .font(UIFont(name: "Zapfino", size: 20)!)
-//                .fontColor(.blue)
-//                .highlightColor(.white)
-//                .backgroundColor(UIColor(red: 0.3, green: 0.6, blue: 0.3, alpha: 0.7))
-//                .edgeStyle(.raised)
-                    // add position created above
-//                .position(position)
                 .allowScaling(true)
                 .build()
             
-            // Supply the style to the player
             playerView.captionStyle = style
         }
         catch {


### PR DESCRIPTION
### Jira Ticket Link.

https://jiratl.kqed.org/browse/KNMA-1822

### Describe the feature or bug-fix.

This PR adds the methods for iOS and Android to set up captions that are passed in through the method channels
There are styling options, but we don't exactly have the same font selections as we do in the Flutter app. The default seems pretty standard for captions. We can always change them later.


### Express how you feel about this PR with a GIF.

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExbDBzMzZjbTFjZGFtN3c5ZThpb2pqMGM5OHBoNDZ6d3NibGtuNG9oZiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/i7GXnfbuaqboyo93ld/giphy.gif)

### What areas of the plugin does it impact?

- Ability to display captions if the data is provided

### How to test? Be specific here. Call out any Environment or Accessibility pieces if applicable.

- In the Flutter app, change the package git `ref` to point to this commit
- Run the Mobile API locally if this [branch](https://github.com/KQED/mobile-app-server/pull/238) isn't merged yet
- Check out this [branch](https://github.com/KQED/flutter-next-gen/pull/659) on the mobile app if not yet merged
- Load a video that has a captions track
  - The one titled `It's Quite a Transformation` works
- See that the captions icon is available to use and will show captions if active

### Was documentation written or updated? If so, provide the link or links.

Docs exist here: https://kb.kqed.org/display/ProDoc/Vertical+Video+-+JW+Player