### PR TITLE
iOS: Disable auto Picture-in-Picture on background by default

### DIFF
--- a/ios/jwplayer/Sources/jwplayer/JwplayerPlatformView.swift
+++ b/ios/jwplayer/Sources/jwplayer/JwplayerPlatformView.swift
@@ -167,6 +167,7 @@ class JwplayerPlatformView: NSObject, FlutterPlatformView {
         }()
         let startPosition = (args["startPosition"] as? NSNumber)?.doubleValue
         let showControls = (args["showControls"] as? NSNumber)?.boolValue ?? false
+        let allowsPictureInPicture = (args["allowsPictureInPicture"] as? NSNumber)?.boolValue ?? false
         loop = (args["loop"] as? NSNumber)?.boolValue ?? false
         isMuted = muted
 
@@ -208,6 +209,7 @@ class JwplayerPlatformView: NSObject, FlutterPlatformView {
                 vc.didMove(toParent: parentVC)
                 vc.player.configurePlayer(with: config)
                 vc.player.volume = muted ? 0 : 1
+                vc.allowsPictureInPicturePlayback = allowsPictureInPicture
                 self.playerViewController = vc
 
                 if loop || muted, let jwPlayer = vc.player as? JWPlayer {
@@ -229,6 +231,7 @@ class JwplayerPlatformView: NSObject, FlutterPlatformView {
                 pv.player.configurePlayer(with: config)
                 self.playerView = pv
                 pv.player.volume = muted ? 0 : 1
+                pv.allowsPictureInPicturePlayback = allowsPictureInPicture
 
                 if loop || muted, let jwPlayer = pv.player as? JWPlayer {
                     let delegate = JwplayerPlaybackDelegate()

--- a/ios/jwplayer/Sources/jwplayer/JwplayerPlugin.swift
+++ b/ios/jwplayer/Sources/jwplayer/JwplayerPlugin.swift
@@ -71,6 +71,7 @@ public class JwplayerPlugin: NSObject, FlutterPlugin {
             let videoDescription = args["videoDescription"] as? String
             let startPosition = args["startPosition"] as? NSNumber
             let loop = (args["loop"] as? NSNumber)?.boolValue ?? false
+            let allowsPictureInPicture = (args["allowsPictureInPicture"] as? NSNumber)?.boolValue ?? false
             guard let args = call.arguments as? [String: Any],
               let captionsArray = args["captions"] as? [[String: Any]] else {
                 result(FlutterError(code: "INVALID_ARGUMENT", message: "Invalid arguments passed", details: nil))
@@ -86,6 +87,7 @@ public class JwplayerPlugin: NSObject, FlutterPlugin {
                 captions,
                 startPosition: startPosition?.doubleValue,
                 loop: loop,
+                allowsPictureInPicture: allowsPictureInPicture,
                 onDismiss: { position in
                     result(position)
                 }
@@ -133,6 +135,7 @@ public class JwplayerPlugin: NSObject, FlutterPlugin {
         _ captions: [Caption]?,
         startPosition: Double? = nil,
         loop: Bool = false,
+        allowsPictureInPicture: Bool = false,
         onDismiss: @escaping (Double) -> Void
     ) {
         if (url == nil) {
@@ -150,6 +153,7 @@ public class JwplayerPlugin: NSObject, FlutterPlugin {
             vc.captions = captions
             vc.startPosition = startPosition
             vc.loop = loop
+            vc.allowsPictureInPicture = allowsPictureInPicture
             vc.onDismiss = onDismiss
             topController.present(vc, animated: true, completion: nil)
             callbackToFlutter(CallbackMethod.sdkPlayMethodCalled, [Arguments.videoUrl.rawValue: url])

--- a/ios/jwplayer/Sources/jwplayer/VerticalPlayerViewController.swift
+++ b/ios/jwplayer/Sources/jwplayer/VerticalPlayerViewController.swift
@@ -35,6 +35,7 @@ class VerticalPlayerViewController: JWPlayerViewController {
     var startPosition: Double?
     var onDismiss: ((Double) -> Void)?
     var loop: Bool = false
+    var allowsPictureInPicture: Bool = false
     
     private let closeButton: UIButton = {
         if #available(iOS 13.0, *) {
@@ -70,6 +71,8 @@ class VerticalPlayerViewController: JWPlayerViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        self.allowsPictureInPicturePlayback = allowsPictureInPicture
 
         // Ensure audio plays on physical devices even when the silent switch is on.
         do {

--- a/lib/jwplayer.dart
+++ b/lib/jwplayer.dart
@@ -13,6 +13,7 @@ class Jwplayer {
     String? videoDescription,
     List<Caption>? captions,
     double? startPosition,
+    bool allowsPictureInPicture = false,
   }) {
     return JwplayerPlatform.instance.play(
       url,
@@ -20,6 +21,7 @@ class Jwplayer {
       videoDescription: videoDescription,
       captions: captions,
       startPosition: startPosition,
+      allowsPictureInPicture: allowsPictureInPicture,
     );
   }
 

--- a/lib/jwplayer_method_channel.dart
+++ b/lib/jwplayer_method_channel.dart
@@ -25,6 +25,7 @@ class MethodChannelJwplayer extends JwplayerPlatform {
     String? videoDescription,
     List<Caption>? captions,
     double? startPosition,
+    bool allowsPictureInPicture = false,
   }) async {
     final result = await methodChannel.invokeMethod<num>('play', {
       "url": url,
@@ -32,6 +33,7 @@ class MethodChannelJwplayer extends JwplayerPlatform {
       "videoDescription": videoDescription,
       "captions": convertCaptions(captions ?? []),
       if (startPosition != null) "startPosition": startPosition,
+      "allowsPictureInPicture": allowsPictureInPicture,
     });
     return result?.toDouble();
   }

--- a/lib/jwplayer_platform_interface.dart
+++ b/lib/jwplayer_platform_interface.dart
@@ -39,6 +39,7 @@ abstract class JwplayerPlatform extends PlatformInterface {
     String? videoDescription,
     List<Caption>? captions,
     double? startPosition,
+    bool allowsPictureInPicture = false,
   }) {
     throw UnimplementedError('play(String url) has not been implemented.');
   }

--- a/lib/jwplayer_widget.dart
+++ b/lib/jwplayer_widget.dart
@@ -34,6 +34,7 @@ class JwplayerWidget extends StatelessWidget {
     this.startPosition,
     this.showControls = false,
     this.loop = false,
+    this.allowsPictureInPicture = false,
     this.onPlatformViewCreated,
   });
 
@@ -66,6 +67,12 @@ class JwplayerWidget extends StatelessWidget {
   /// Defaults to false.
   final bool loop;
 
+  /// When true (iOS only), allows the native player to enter Picture in
+  /// Picture, including auto-starting it when the app is backgrounded.
+  /// Defaults to false, since our vertical/short-form video use cases don't
+  /// want the video staying on screen as a mini player when backgrounded.
+  final bool allowsPictureInPicture;
+
   /// Called when the native view is created, with the platform view ID.
   /// Use this to call [setJwplayerViewMuted] when toggling mute.
   final void Function(int viewId)? onPlatformViewCreated;
@@ -85,6 +92,7 @@ class JwplayerWidget extends StatelessWidget {
     }
     params['showControls'] = showControls;
     params['loop'] = loop;
+    params['allowsPictureInPicture'] = allowsPictureInPicture;
     return params;
   }
 


### PR DESCRIPTION
JWPlayerKit defaults allowsPictureInPicturePlayback to true, so backgrounding the app while a vertical video autoplays let iOS auto-start its PiP mini-player over the home screen — undesirable for our short-form video feed. Add an allowsPictureInPicture param (default false) threaded through JwplayerWidget and Jwplayer.play(), applied on iOS to the inline feed player, the showControls player, and the full-screen VerticalPlayerViewController. Android is unaffected; no equivalent behavior exists there.